### PR TITLE
Stopped onPageChange event firing when selecting the same page.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ let { width } = Dimensions.get("window");
 export default class Carousel extends Component {
 
     displayName = "Carousel";
+    selectedPage = 0;
 
     static propTypes = {
         pageStyle: PropTypes.object,
@@ -48,6 +49,12 @@ export default class Carousel extends Component {
         }
     }
 
+    componentDidUpdate (prevProps) {
+        if (this.props.children && prevProps.children && this.props.children.length !== prevProps.children.length) {
+            this.goToPage(this.props.initialPage);
+        }
+    }
+
     componentWillReceiveProps(props) {
         this.calculateGap(props);
     }
@@ -75,21 +82,23 @@ export default class Carousel extends Component {
     }
 
     goToPage(position) {
-        let { pageWidth, transitionDelay } = this.props;
-        let { gap } = this.state;
-        let pagePosition = position * (pageWidth + gap);
-        // in android, you can't scroll directly in componentDidMount
-        // (http://stackoverflow.com/questions/33208477/react-native-android-scrollview-scrollto-not-working)
-        // however this doesn't work in android for some reason:
-        // InteractionManager.runAfterInteractions(() => {
-        //     this.scrollView.scrollTo({ y: 0, x: pagePosition}, true);
-        //     console.log('scrollView.scrollTo x:', pagePosition);
-        // });
-        // So I was left with an arbitrary timeout.
-        setTimeout(()=> {
-            this.scrollView.scrollTo({ y: 0, x: pagePosition}, true);
-        }, transitionDelay);
-        this._onPageChange(position);
+        if (position !== this.selectedPage) {
+            let { pageWidth, transitionDelay } = this.props;
+            let { gap } = this.state;
+            let pagePosition = position * (pageWidth + gap);
+            // in android, you can't scroll directly in componentDidMount
+            // (http://stackoverflow.com/questions/33208477/react-native-android-scrollview-scrollto-not-working)
+            // however this doesn't work in android for some reason:
+            // InteractionManager.runAfterInteractions(() => {
+            //     this.scrollView.scrollTo({ y: 0, x: pagePosition}, true);
+            //     console.log('scrollView.scrollTo x:', pagePosition);
+            // });
+            // So I was left with an arbitrary timeout.
+            setTimeout(()=> {
+                this.scrollView.scrollTo({ y: 0, x: pagePosition}, true);
+            }, transitionDelay);
+            this._onPageChange(position);
+        }
     }
 
     handleScrollEnd = (e) => {
@@ -101,10 +110,13 @@ export default class Carousel extends Component {
         let currentPage = ~~(currentPosition / pageOffset);
 
         this.scrollView.scrollTo({ y: 0, x: currentPage * pageOffset });
-        this._onPageChange(currentPage);
+        if (currentPage !== this.selectedPage) {
+            this._onPageChange(currentPage);
+        }
     };
 
     _onPageChange(position) {
+        this.selectedPage = position;
         if (this.props.onPageChange) {
             let currentElement = this.props.children[position];
             this.props.onPageChange(position, currentElement);


### PR DESCRIPTION
Not sure if this is something you wanted but I needed it so thought I'd create a PR in case you would like it too.

I also have a variable number of children (always adding to the start of the list), so when the number of children changes I need to reset the initPage.
