### PR TITLE
Allows to swipe more than one page

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,13 +164,8 @@ export default class Carousel extends Component {
 
         const swiped = (currentScrollX - currentPageScrollX) / this._getPageOffset();
 
-        let newPage = currentPage;
-
-        if (currentPage + 1 < this._getPagesCount() && swipeThreshold < swiped) {
-            newPage++;
-        } else if (0 < currentPage && swiped < -swipeThreshold) {
-            newPage--;
-        }
+        const pagesSwiped = Math.floor(Math.abs(swiped) + (1 - swipeThreshold)) * Math.sign(swiped);
+        const newPage = Math.max(Math.min(currentPage + pagesSwiped, this._getPagesCount() - 1), 0)
 
         if (newPage !== currentPage) {
             this.setState({currentPage: newPage});


### PR DESCRIPTION
This commit allows to swipe more than one page at time. It's useful when more than three items are visible at a time. Looks like it shouldn't brake anything. There's the following relation between swiped and pagesSwiped (for threshold = .5):

| swiped  | pagesSwiped |
| --- | --- |
| .4 | 0 |
| .6 | 1 |
| 1.4 | 1 |
| 1.6 | 2 |
| -.4 | 0 |
| -.6 | -1 |